### PR TITLE
feat: add Task entity with title and status (#1)

### DIFF
--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Delete;
+use App\Enum\TaskStatus;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'tasks')]
+#[ORM\HasLifecycleCallbacks]
+#[ApiResource(
+    operations: [
+        new GetCollection(),
+        new Post(),
+        new Get(),
+        new Patch(),
+        new Delete(),
+    ]
+)]
+class Task
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    private Uuid $id;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    private string $title;
+
+    #[ORM\Column(enumType: TaskStatus::class)]
+    private TaskStatus $status = TaskStatus::PENDING;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $this->id = Uuid::v4();
+        $this->status = TaskStatus::PENDING;
+    }
+
+    #[ORM\PrePersist]
+    public function onPrePersist(): void
+    {
+        $now = new \DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    // ---------- getters & setters ----------
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getStatus(): TaskStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(TaskStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Enum/TaskStatus.php
+++ b/api/src/Enum/TaskStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum TaskStatus: string
+{
+    case PENDING = 'pending';
+    case IN_PROGRESS = 'in_progress';
+    case DONE = 'done';
+}

--- a/api/tests/Api/TaskApiTest.php
+++ b/api/tests/Api/TaskApiTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Enum\TaskStatus;
+
+class TaskApiTest extends ApiTestCase
+{
+    public function testCreateTask(): void
+    {
+        static::createClient()->request('POST', '/api/tasks', [
+            'json' => [
+                'title' => 'My first task',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'title' => 'My first task',
+            'status' => TaskStatus::PENDING->value,
+        ]);
+    }
+
+    public function testListTasks(): void
+    {
+        static::createClient()->request('GET', '/api/tasks');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+    }
+
+    public function testUpdateTaskStatus(): void
+    {
+        $client = static::createClient();
+
+        // create
+        $response = $client->request('POST', '/api/tasks', [
+            'json' => ['title' => 'Update status test'],
+        ]);
+
+        $data = $response->toArray();
+        $iri = $data['@id'];
+
+        // patch
+        $client->request('PATCH', $iri, [
+            'json' => ['status' => TaskStatus::DONE->value],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'status' => TaskStatus::DONE->value,
+        ]);
+    }
+
+    public function testDeleteTask(): void
+    {
+        $client = static::createClient();
+
+        $response = $client->request('POST', '/api/tasks', [
+            'json' => ['title' => 'To be deleted'],
+        ]);
+
+        $iri = $response->toArray()['@id'];
+
+        $client->request('DELETE', $iri);
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+}

--- a/api/tests/Entity/TaskTest.php
+++ b/api/tests/Entity/TaskTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\Task;
+use App\Enum\TaskStatus;
+use PHPUnit\Framework\TestCase;
+
+class TaskTest extends TestCase
+{
+    public function testDefaultStatusIsPending(): void
+    {
+        $task = new Task();
+        $this->assertSame(TaskStatus::PENDING, $task->getStatus());
+    }
+
+    public function testCanSetTitleAndStatus(): void
+    {
+        $task = new Task();
+        $task->setTitle('Test Task');
+        $task->setStatus(TaskStatus::IN_PROGRESS);
+
+        $this->assertSame('Test Task', $task->getTitle());
+        $this->assertSame(TaskStatus::IN_PROGRESS, $task->getStatus());
+    }
+}


### PR DESCRIPTION
This PR implements the Task entity for issue #1.
The Task model includes a UUID id, title, status enum, and timestamp fields.
API Platform CRUD endpoints for /api/tasks are also added.

The entity uses lifecycle callbacks for createdAt and updatedAt, and the default status is set to pending.
Basic unit tests and API tests are included to cover the main behavior.

Closes #1
